### PR TITLE
render 3-day view on narrow screens

### DIFF
--- a/backend/app/app/static/js/profile.js
+++ b/backend/app/app/static/js/profile.js
@@ -206,10 +206,12 @@ async function open_trainer_modal({event}) {
     modal.append(make_grades_table(grades, duration_academic_hours));
 }
 
-document.addEventListener('DOMContentLoaded', function () {
-    let calendarEl = document.getElementById('calendar');
 
-    let calendar = new FullCalendar.Calendar(calendarEl, {
+document.addEventListener('DOMContentLoaded', function () {
+    const tabletWidth = 768; // if width is less than this, then week view renders poorly.
+    let calendarEl = document.getElementById('calendar');
+    let calendar;
+    let calendar_setting = {
         plugins: ['timeGrid'],
         defaultView: 'timeGridWeek',
         header: {
@@ -218,6 +220,7 @@ document.addEventListener('DOMContentLoaded', function () {
             // right: '',
             right: 'today, prev, next',
         },
+        views: {},
         height: 'auto',
         timeZone: 'Europe/Moscow',
         firstDay: 1,
@@ -227,11 +230,28 @@ document.addEventListener('DOMContentLoaded', function () {
         maxTime: '21:00:00',
         defaultTimedEventDuration: '01:30',
         eventRender: render,
-        // datesRender: clearColors,
         eventClick: open_trainer_modal,
+        windowResize: function (view) {
+            // change view on scree rotation
+            if (screen.width < tabletWidth) {
+                calendar.changeView('timeGridThreeDay');
+            } else {
+                calendar.changeView('timeGridWeek');
+            }
+        },
         // Event format: yyyy-mm-dd
         events: '/api/calendar/trainings'
-    });
+    };
 
+    if (screen.width < tabletWidth) {
+        calendar_setting.defaultView = 'timeGridThreeDay';
+        calendar_setting.views.timeGridThreeDay = {
+            type: 'timeGrid',
+            duration: {days: 3},
+            buttonText: '3 day'
+        };
+    }
+
+    calendar = new FullCalendar.Calendar(calendarEl, calendar_setting);
     calendar.render();
 });

--- a/backend/app/app/static/js/profile.js
+++ b/backend/app/app/static/js/profile.js
@@ -241,7 +241,7 @@ document.addEventListener('DOMContentLoaded', function () {
         eventClick: open_trainer_modal,
         windowResize: function (view) {
             // change view on scree rotation
-            if (screen.width < tabletWidth) {
+            if (document.body.clientWidth < tabletWidth) {
                 calendar.changeView('timeGridThreeDay');
             } else {
                 calendar.changeView('timeGridWeek');
@@ -251,7 +251,7 @@ document.addEventListener('DOMContentLoaded', function () {
         events: '/api/calendar/trainings'
     };
 
-    if (screen.width < tabletWidth) {
+    if (document.body.clientWidth < tabletWidth) {
         calendar_setting.defaultView = 'timeGridThreeDay';
         calendar_setting.views.timeGridThreeDay = {
             type: 'timeGrid',

--- a/backend/app/app/static/js/profile.js
+++ b/backend/app/app/static/js/profile.js
@@ -220,7 +220,15 @@ document.addEventListener('DOMContentLoaded', function () {
             // right: '',
             right: 'today, prev, next',
         },
-        views: {},
+        views: {
+            timeGridThreeDay: {
+                type: 'timeGrid',
+                duration: {
+                    days: 3
+                },
+                buttonText: '3 day',
+            }
+        },
         height: 'auto',
         timeZone: 'Europe/Moscow',
         firstDay: 1,


### PR DESCRIPTION
If the screen width is less than 768px (standard tablet width), the calendar will render 3-day view, otherwise - weekly