### PR TITLE
Setup a docker-compose to start in development/production mode

### DIFF
--- a/adminpage/adminpage/settings.py
+++ b/adminpage/adminpage/settings.py
@@ -33,9 +33,12 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = os.getenv("SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = getenv_boolean("DEBUG", default_value=False)
+DEBUG = getenv_boolean("DEBUG", False)
 
-ALLOWED_HOSTS = ['188.130.155.115', 'helpdesk.innopolis.university', 'localhost']
+ALLOWED_HOSTS = ['188.130.155.115', 'helpdesk.innopolis.university']
+
+if DEBUG:
+    ALLOWED_HOSTS.append('localhost')
 
 # Application definition
 
@@ -84,10 +87,6 @@ WSGI_APPLICATION = 'adminpage.wsgi.application'
 
 
 DATABASES = {
-    # 'default': {
-    #     'ENGINE': 'django.db.backends.sqlite3',
-    #     'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
-    # }
     'default': {
         "ENGINE": 'django.db.backends.postgresql',
         'NAME': os.getenv("POSTGRES_DB"),

--- a/backend/app/app/core/config.py
+++ b/backend/app/app/core/config.py
@@ -15,7 +15,8 @@ SC_TRAINERS_GROUP_NAME = "SC trainers"
 BACHELOR_PREFIX = "B"
 TIMEZONE = pytz.timezone("Europe/Moscow")
 
-DEBUG = FAKE_LOGIN = getenv_boolean("DEBUG", False)
+DEBUG = getenv_boolean("DEBUG", False)
+FAKE_LOGIN = DEBUG
 
 API_V1_STR = "/api"
 DOCS_STR = "/docs"

--- a/backend/app/app/main.py
+++ b/backend/app/app/main.py
@@ -15,9 +15,13 @@ logger.setLevel(logging.DEBUG)
 
 app = FastAPI(title=config.PROJECT_NAME)
 
-
 app.include_router(pages_router)
 app.include_router(api_router, prefix=config.API_V1_STR)
+
+if config.DEBUG:
+    from fastapi.staticfiles import StaticFiles
+
+    app.mount("/static", StaticFiles(directory="app/static"), name="static")
 
 
 @app.middleware("http")
@@ -39,4 +43,3 @@ async def http_exception_handler(request: Request, exc: HTTPException):
 
     else:
         return await default_http_exception_handler(request, exc)
-

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     restart: always
     build:
       context: ../nginx
+      args:
+        - DEBUG
     ports:
       - "81:80"
     depends_on:
@@ -23,19 +25,31 @@ services:
     ports:
       - "8082:80"
     restart: always
-    env_file:
-      - .env
     depends_on:
       - db
     volumes:
       - ../backend/app:/app
       - fastapi-static:/static
+    environment:
+      - DEBUG
+      - POSTGRES_USER
+      - POSTGRES_PASSWORD
+      - POSTGRES_DB
+      - POSTGRES_SERVER
+      - PROJECT_NAME
+      - SECRET_KEY
+      - oauth_appID
+      - oauth_shared_secret
+      - oauth_authorization_baseURL
+      - oauth_get_infoURL
+      - oauth_tokenURL
+      - oauth_end_session_endpoint
 
   adminpanel:
     build:
       context: ../adminpage
       dockerfile: Dockerfile
-#   Wait for postgres to startup before running server
+    #   Wait for postgres to startup before running server
     command: bash -c 'while !</dev/tcp/db/5432; do sleep 1; done; python manage.py runserver 0.0.0.0:8000'
     restart: always
     volumes:
@@ -45,10 +59,14 @@ services:
       - "8000:8000"
     depends_on:
       - db
-    env_file:
-      - .env
     environment:
-      DOCKER: 1
+      - DEBUG
+      - POSTGRES_USER
+      - POSTGRES_PASSWORD
+      - POSTGRES_DB
+      - POSTGRES_SERVER
+      - SECRET_KEY
+      - PROJECT_NAME
 
   db:
     image: db
@@ -60,8 +78,11 @@ services:
       - "5432:5432"
     volumes:
       - db-data:/var/lib/postgresql/data
-    env_file:
-      - .env
+    environment:
+      - POSTGRES_USER
+      - POSTGRES_PASSWORD
+      - POSTGRES_DB
+      - POSTGRES_SERVER
 
 
   adminer:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,7 +1,16 @@
 FROM nginx:alpine
 
+ARG DEBUG
+# If DEBUG is set (EVEN TO NULLSTRING),
+# FILENAME become == dev otherwise nullstring
+ARG FILENAME=${DEBUG:+dev}
+# If FILENAME is nullstring, set it to prod or untouch
+ARG FILENAME=${FILENAME:-prod}
+
+#RUN echo ${FILENAME}
+
 # adding configuration files
 RUN rm -rf /etc/nginx/conf.d/*
-COPY conf/* /etc/nginx/conf.d/
+COPY conf/${FILENAME}.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80

--- a/nginx/conf/dev.conf
+++ b/nginx/conf/dev.conf
@@ -1,0 +1,30 @@
+server {
+    listen 80;
+
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto http;
+    proxy_set_header Host $host;
+
+    location / {
+        proxy_pass http://backend:80;
+
+        proxy_buffer_size       128k;
+        proxy_buffers           4 256k;
+        proxy_busy_buffers_size 256k;
+    }
+
+    location /admin {
+        proxy_pass http://adminpanel:8000/admin;
+
+        proxy_buffer_size       128k;
+        proxy_buffers           4 256k;
+        proxy_busy_buffers_size 256k;
+    }
+
+    location = /favicon.ico {
+        alias /static/favicon.ico;
+    }
+}
+

--- a/nginx/conf/prod.conf
+++ b/nginx/conf/prod.conf
@@ -30,12 +30,5 @@ server {
     location = /favicon.ico {
         alias /static/favicon.ico;
     }
-
-    location /__/pgres {
-        auth_basic "SupportBot DB Management";
-        auth_basic_user_file /etc/nginx/access.d/admin.users;
-
-        proxy_pass http://adminer:8080/;
-    }
 }
 


### PR DESCRIPTION
if `DEBUG` environment is set (even to nullstring), then development Nginx configuration is set. For production mode do not set `DEBUG` env var (comment it in `.env` file)

if dev config is used, django serve it's static files, fastAPI - its. So it is possible to fast-reload statics.


Before usage, rebuild everything: `docker-compose up --build`