### PR TITLE
Fix/show group verbose name

### DIFF
--- a/adminpage/sport/models/__init__.py
+++ b/adminpage/sport/models/__init__.py
@@ -21,10 +21,10 @@ DjangoGroup.add_to_class(
 
 DjangoGroup.add_to_class(
     "__str__",
-    lambda self: self.verbose_name
+    lambda self: str(self.verbose_name)
 )
 
 DjangoGroup.add_to_class(
     "natural_key",
-    lambda self: (self.verbose_name, )
+    lambda self: (str(self.verbose_name), )
 )

--- a/adminpage/sport/models/__init__.py
+++ b/adminpage/sport/models/__init__.py
@@ -18,3 +18,13 @@ DjangoGroup.add_to_class(
         unique=True,
         )
     )
+
+DjangoGroup.add_to_class(
+    "__str__",
+    lambda self: self.verbose_name
+)
+
+DjangoGroup.add_to_class(
+    "natural_key",
+    lambda self: (self.verbose_name, )
+)


### PR DESCRIPTION
Make group return `verbose_name` instead of `name`